### PR TITLE
Fix for flaky tests

### DIFF
--- a/tests/scenarios/po/selectors_page.py
+++ b/tests/scenarios/po/selectors_page.py
@@ -6,7 +6,7 @@ class Page(RobotPage):
     selectors = {
         "search-button": "css=#go",
         "inputs": "css=input",
-        "remove-button": "css=button#remove-content",
-        "para-to-be-removed": "css=p#disappear",
+        "hide-button": "css=button#hide-content",
+        "para-to-be-hidden": "css=p#disappear",
         "delayed-content-button":"css=button#delayed-content"
     }

--- a/tests/scenarios/site/index.html
+++ b/tests/scenarios/site/index.html
@@ -26,10 +26,10 @@
         </div>
 
         <br><hr>
-        <div class="ct-to-be-removed">
-            <p id="disappear">I am another paragraph added to test remove button</p>
+        <div class="ct-to-be-hidden">
+            <p id="disappear">I am another paragraph added to test hide button</p>
         </div>
-        <button id="remove-content">Click to remove content</button>
+        <button id="hide-content">Click to hide content</button>
 
 
     </form>
@@ -63,10 +63,10 @@
         });
 
         // clicking on remove me button removes the delayed content
-        jQuery("#remove-content").click( function(e) {
+        jQuery("#hide-content").click( function(e) {
             e.preventDefault();
             setTimeout( function() {
-                jQuery(".ct-to-be-removed").remove();
+                jQuery(".ct-to-be-hidden").hide();
             }, 5000);
         });
 

--- a/tests/scenarios/test_wait_until_not_visible.py
+++ b/tests/scenarios/test_wait_until_not_visible.py
@@ -10,12 +10,12 @@ class WaitUntilNotVisibleTestCase(unittest.TestCase):
     def test_wait_until_element_not_visible(self):
         self.p.click_element("hide-button")
         self.p.wait_until_element_is_not_visible("para-to-be-hidden")
-        self.p.page_should_not_contain_element("para-to-be-hidden")
+        self.p.element_should_not_be_visible("para-to-be-hidden")
 
     def test_wait_for_element_not_visible(self):
         self.p.click_element("hide-button")
         self.p.wait_for(lambda: not self.p.is_visible("para-to-be-hidden"))
-        self.p.page_should_not_contain_element("para-to-be-hidden")
+        self.p.element_should_not_be_visible("para-to-be-hidden")
 
     def test_wait_until_element_not_visible_throws_exception(self):
         try:

--- a/tests/scenarios/test_wait_until_not_visible.py
+++ b/tests/scenarios/test_wait_until_not_visible.py
@@ -8,19 +8,19 @@ class WaitUntilNotVisibleTestCase(unittest.TestCase):
         self.p.open()
 
     def test_wait_until_element_not_visible(self):
-        self.p.click_element("remove-button")
-        self.p.wait_until_element_is_not_visible("para-to-be-removed")
-        self.p.page_should_not_contain_element("para-to-be-removed")
+        self.p.click_element("hide-button")
+        self.p.wait_until_element_is_not_visible("para-to-be-hidden")
+        self.p.page_should_not_contain_element("para-to-be-hidden")
 
     def test_wait_for_element_not_visible(self):
-        self.p.click_element("remove-button")
-        self.p.wait_for(lambda: not self.p.is_visible("para-to-be-removed"))
-        self.p.page_should_not_contain_element("para-to-be-removed")
+        self.p.click_element("hide-button")
+        self.p.wait_for(lambda: not self.p.is_visible("para-to-be-hidden"))
+        self.p.page_should_not_contain_element("para-to-be-hidden")
 
     def test_wait_until_element_not_visible_throws_exception(self):
         try:
             self.p.click_element("delayed-content-button")
-            self.p.wait_until_element_is_not_visible("para-to-be-removed", 8)
+            self.p.wait_until_element_is_not_visible("para-to-be-hidden", 8)
         except Exception, e:
             self.assertTrue(isinstance(e, AssertionError))
             self.assertIn("still matched after", e.message)
@@ -28,7 +28,7 @@ class WaitUntilNotVisibleTestCase(unittest.TestCase):
     def test_wait_for_element_not_visible_throws_exception(self):
         try:
             self.p.click_element("delayed-content-button")
-            self.p.wait_for(lambda: not self.p.is_visible("para-to-be-removed"), 8, 'Element did not disappear')
+            self.p.wait_for(lambda: not self.p.is_visible("para-to-be-hidden"), 8, 'Element did not disappear')
         except Exception, e:
             self.assertIn("Element did not disappear", e.msg)
 


### PR DESCRIPTION
This has to do with tests that were discovered as flaky in https://github.com/ncbi/robotframework-pageobjects/pull/25. These are tests for keywords that check visibility, but they were using removal of page elements instead of hiding. This fixes that so the elements are hidden instead.