### PR TITLE
Fix for attempted screenshots in get_keyword_names

### DIFF
--- a/robotpageobjects/base.py
+++ b/robotpageobjects/base.py
@@ -50,14 +50,31 @@ class _Keywords(object):
             return False
 
     @classmethod
-    def is_obj_keyword_by_name(cls, name, klass):
-        """ Determines whether a given name from the given class is a keyword
+    def is_obj_keyword_by_name(cls, name, inst):
+        """ Determines whether a given name from the given class instance is a keyword.
+        This is used by `get_keyword_names` in `robotpageobjects.page.Page` to decide
+        what keyword names to report.
+        :param name: The name of the member to check
+        :type name: str
+        :param inst: The class instance to check (such as a page object)
+        :type inst: object
         """
         obj = None
+        # If obj is a @property as oppose to a regular method or attribute,
+        # its method will be called immediately. This could cause an attempt
+        # to retrieve an element via webdriver, but when this method is called
+        # no browser is open, so that will cause Selenium2Library's decorator
+        # to attempt a screenshot - which will fail, because no browser is open.
+        # To prevent this, we temporarily set inst._has_run_on_failure to True.
+        # (_has_run_on_failure is used by Selenium2Library's decorator to prevent
+        # redundant screenshot attempts.)
+        inst._has_run_on_failure = True
         try:
-            obj = getattr(klass, name)
+            obj = getattr(inst, name)
         except Exception:
+            inst._has_run_on_failure = False
             return False
+        inst._has_run_on_failure = False
 
         return cls.is_obj_keyword(obj)
 
@@ -315,7 +332,8 @@ class _ComponentsManagerMeta(KeywordGroupMetaClass):
             # Update the return dict with this class's selectors, overriding the bases
             all_components.merge(own_components, from_subclass=True)
             return all_components
-        return get_components(classdict, bases)
+        ret = get_components(classdict, bases)
+        return ret
 
     @classmethod
     def _set_components(cls, components, classdict):
@@ -352,7 +370,8 @@ class _ComponentsManagerMeta(KeywordGroupMetaClass):
     def __new__(cls, name, bases, classdict):
         components = cls._get_class_components(bases, classdict)
         cls._set_components(components, classdict)
-        return KeywordGroupMetaClass.__new__(cls, name, bases, classdict)
+        ret = KeywordGroupMetaClass.__new__(cls, name, bases, classdict)
+        return ret
 
 
 class _ComponentsManager(object):
@@ -690,7 +709,6 @@ class _BaseActions(_S2LWrapper):
         :type locator: str or WebElement
         :returns: WebElement or list
         """
-
         if isinstance(locator, WebElement):
             return locator
 
@@ -700,7 +718,9 @@ class _BaseActions(_S2LWrapper):
         if "wait" in kwargs:
             del kwargs["wait"]
 
+
         self.driver.implicitly_wait(our_wait)
+        
 
         if locator in self.selectors:
             locator = self.resolve_selector(locator)

--- a/robotpageobjects/base.py
+++ b/robotpageobjects/base.py
@@ -332,8 +332,7 @@ class _ComponentsManagerMeta(KeywordGroupMetaClass):
             # Update the return dict with this class's selectors, overriding the bases
             all_components.merge(own_components, from_subclass=True)
             return all_components
-        ret = get_components(classdict, bases)
-        return ret
+        return get_components(classdict, bases)
 
     @classmethod
     def _set_components(cls, components, classdict):
@@ -370,8 +369,7 @@ class _ComponentsManagerMeta(KeywordGroupMetaClass):
     def __new__(cls, name, bases, classdict):
         components = cls._get_class_components(bases, classdict)
         cls._set_components(components, classdict)
-        ret = KeywordGroupMetaClass.__new__(cls, name, bases, classdict)
-        return ret
+        return KeywordGroupMetaClass.__new__(cls, name, bases, classdict)
 
 
 class _ComponentsManager(object):

--- a/tests/scenarios/po/page_with_component.py
+++ b/tests/scenarios/po/page_with_component.py
@@ -1,0 +1,9 @@
+from robotpageobjects import Page, Component
+
+class FormComponent(Component):
+    pass
+
+class Page(Page):
+    uri = "/site/index.html"
+
+    components = {FormComponent: "css=form"}

--- a/tests/scenarios/test_page_with_component.robot
+++ b/tests/scenarios/test_page_with_component.robot
@@ -1,0 +1,10 @@
+*** Settings ***
+
+Documentation  Simple test using a page with a component
+Library    page_with_component.Page
+
+*** Test Cases ***
+
+Test Widget Site
+    Open Page
+    [Teardown]  Close Page

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -74,6 +74,12 @@ class SmokeTestCase(BaseTestCase):
         run = self.run_scenario("test_stack_trace.robot", v="baseurl:%s" % self.base_file_url, L="TRACE")
         self.assert_run(run, expected_returncode=1, search_output_xml="in raise_division_by_zero")
 
+    def test_no_screenshot_attempt_on_initializing_page_with_component(self):
+        self.set_baseurl_env()
+        run = self.run_scenario("test_page_with_component.robot")
+        self.assert_run(run, expected_returncode=0, search_output="PASS",
+                        not_in_output="Capture Page Screenshot")
+
 
 
 class SauceTestCase(BaseTestCase):


### PR DESCRIPTION
Summary of the problem:

Version 1.3.0 (which was rolled back) causes a screenshot warning whenever components are used. This also breaks output.xml. This happens because get_keyword_names is called on every Page subclass when Robot loads it: https://github.com/ncbi/robotframework-pageobjects/blob/1.2.1/robotpageobjects/page.py#L209 get_keyword_names iterates over all public members of the class, including @properties. https://github.com/ncbi/robotframework-pageobjects/blob/1.2.1/robotpageobjects/base.py#L56 Retrieving a @property member from a class causes its immediate evaluation. The problem with this is that some properties (such as those automatically added to point to component instances) require an open browser (driver) before they can be evaluated. We therefore wrap the getattr call that retrieves these properties in a try/except. The problem with that is that the run-on-failure decorator still fires within the try, attempting a screenshot, which fails because there is no open browser, and the warning that it failed is still logged.

This wasn't a problem in the old version of RF-PO, because the run-on-failure keyword was set to "None", so that no screenshot was attempted within the try. It was set to "None" as a workaround for the bug where multiple screenshots were attempted when one keyword wrapped another keyword. Now that that is no longer necessary, the workaround was taken out, but that caused this bug. Blargh.

As for why the travis build passed, I suspect it's because all our tests passed, warning and busted output files or no.

This fix prevents the screenshot attempt within the aforementioned try/except by setting the {{_has_run_on_failure}} property to {{False}} (see the diff).